### PR TITLE
ISO-8601 date strings and JSON-LD context tweaks

### DIFF
--- a/lib/connections-context.js
+++ b/lib/connections-context.js
@@ -4,7 +4,7 @@ module.exports = {
 	xsd: 'http://www.w3.org/2001/XMLSchema#',
 	lc: 'http://semweb.mmlab.be/ns/linkedconnections#',
 	hydra: 'http://www.w3.org/ns/hydra/core#',
-	// gtfs: 'http://vocab.gtfs.org/terms#',
+	gtfs: "http://vocab.gtfs.org/terms#",
 	Connection: 'lc:Connection',
 	CancelledConnection: 'lc:CancelledConnection',
 	arrivalTime: {
@@ -31,11 +31,14 @@ module.exports = {
 		'@id': 'lc:arrivalDelay',
 		'@type': 'xsd:integer'
 	},
+	trip: {
+	  "@id": "gtfs:trip",
+      "@type": "@id"
+    },
 	// direction: {
 	// 	@id: 'gtfs:headsign',
 	// 	@type: 'xsd:string'
 	// },
-	// 'gtfs:trip': {'@type': '@id'},
 	// 'gtfs:route': {'@type': '@id'},
 	// 'gtfs:pickupType': {'@type': '@id'},
 	// 'gtfs:dropOffType': {'@type': '@id'},

--- a/lib/connections-context.js
+++ b/lib/connections-context.js
@@ -4,7 +4,7 @@ module.exports = {
 	xsd: 'http://www.w3.org/2001/XMLSchema#',
 	lc: 'http://semweb.mmlab.be/ns/linkedconnections#',
 	hydra: 'http://www.w3.org/ns/hydra/core#',
-	gtfs: "http://vocab.gtfs.org/terms#",
+	gtfs: 'http://vocab.gtfs.org/terms#',
 	Connection: 'lc:Connection',
 	CancelledConnection: 'lc:CancelledConnection',
 	arrivalTime: {
@@ -32,8 +32,8 @@ module.exports = {
 		'@type': 'xsd:integer'
 	},
 	trip: {
-	  "@id": "gtfs:trip",
-      "@type": "@id"
+	  '@id': 'gtfs:trip',
+      '@type': '@id'
     },
 	// direction: {
 	// 	@id: 'gtfs:headsign',

--- a/lib/stops-context.js
+++ b/lib/stops-context.js
@@ -1,10 +1,10 @@
 'use strict'
 
 module.exports = {
-    "schema": "http://schema.org/",
-    "name": "http://xmlns.com/foaf/0.1/name",
-    "longitude": "http://www.w3.org/2003/01/geo/wgs84_pos#long",
-    "latitude": "http://www.w3.org/2003/01/geo/wgs84_pos#lat",
+    schema: 'http://schema.org/',
+    name: 'http://xmlns.com/foaf/0.1/name',
+    longitude: 'http://www.w3.org/2003/01/geo/wgs84_pos#long',
+    latitude: 'http://www.w3.org/2003/01/geo/wgs84_pos#lat',
     // "alternative": "http://purl.org/dc/terms/alternative",
     // "avgStopTimes": "http://semweb.mmlab.be/ns/stoptimes#avgStopTimes",
 }

--- a/lib/stops-context.js
+++ b/lib/stops-context.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = {
+    "schema": "http://schema.org/",
+    "name": "http://xmlns.com/foaf/0.1/name",
+    "longitude": "http://www.w3.org/2003/01/geo/wgs84_pos#long",
+    "latitude": "http://www.w3.org/2003/01/geo/wgs84_pos#lat",
+    // "alternative": "http://purl.org/dc/terms/alternative",
+    // "avgStopTimes": "http://semweb.mmlab.be/ns/stoptimes#avgStopTimes",
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"date-fns": "^2.4.1",
 		"date-fns-tz": "^1.0.7",
 		"express": "^4.17.1",
+		"hafas-find-stations": "^1.1.0",
 		"hafas-monitor-trips": "^2.1.2",
 		"lodash": "^4.17.15",
 		"p-queue": "^6.1.1"


### PR DESCRIPTION
Some small changes:
* ISO-8601 date strings where applicable 
* Gave the stops endpoint its own JSON-LD context 
* Added a trip identifier. Although it's not mandatory according to the LC spec, it's something route planning applications will need. 

I have noticed that sometimes the arrivalTime defaults to 1970-01-01, but couldn't really track down what's causing it. Might be something to keep an eye on. 

The data is now usable with the dev branch of [plannerjs](https://github.com/openplannerteam/planner.js/tree/dev), if you're interested. For example:

```javascript 
const planner = new FlexibleTransitPlanner();
planner.addConnectionSource("http://localhost:3000/connections");
planner.addStopSource("http://localhost:3000/stops");

EventBus
    .on(EventType.Query, (Query) => {
        console.log("Query", Query);
    })
    .on(EventType.LDFetchGet, (url, duration) => {
        console.log(`[GET] ${url} (${duration}ms)`);
    })
    .on(EventType.Warning, (e) => {
        console.warn(e);
    });

planner
    .query({
        from: "http://localhost:3000/stops/900000100513",
        to: "http://localhost:3000/stops/900000100018",
        minimumDepartureTime: new Date("2019-12-19T17:12:24.217Z"),
    })
    .on("data", (path) => {
        console.log(JSON.stringify(path, null, " "));
    });
```